### PR TITLE
DI friendly API client constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use Scopus\ScopusApi;
 
 // replace with your API key
 $apiKey = "114ff0c3b57a0ec62e15efdedefd2e6f";
-$api = new ScopusApi($apiKey);
+$api = (new ScopusApiFactory($apiKey))->createApiClient();
 
 // Scopus Search API
 $results = $api

--- a/src/Scopus/ScopusApiFactory.php
+++ b/src/Scopus/ScopusApiFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Scopus;
+
+use GuzzleHttp\Client;
+
+class ScopusApiFactory
+{
+    const TIMEOUT_DEFAULT = 40;
+
+    private $apiKey;
+    private $institutionToken;
+    private $timeout;
+
+    public function __construct(string $apiKey, string $institutionToken = null, int $timeout = self::TIMEOUT_DEFAULT)
+    {
+        $this->apiKey = $apiKey;
+        $this->institutionToken = $institutionToken;
+        $this->timeout = $timeout;
+    }
+
+    public function createApiClient(): ScopusApi
+    {
+        $headers = [
+            'Accept' => 'application/json',
+            'X-ELS-APIKey' => $this->apiKey,
+        ];
+
+        if ($this->institutionToken !== null) {
+            $headers['X-ELS-Insttoken'] = $this->institutionToken;
+        }
+
+        return new ScopusApi(
+            new Client([
+                'timeout' => $this->timeout,
+                'headers' => $headers,
+            ])
+        );
+    }
+}

--- a/test/test.php
+++ b/test/test.php
@@ -1,6 +1,6 @@
 <?php
 
-use Scopus\ScopusApi;
+use Scopus\ScopusApiFactory;
 
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -11,7 +11,7 @@ require './vendor/autoload.php';
 // replace with your API key
 $apiKey = "114ff0c3b57a0ec62e15efdedefd2e6f";
 
-$api = new ScopusApi($apiKey);
+$api = (new ScopusApiFactory($apiKey))->createApiClient();
 
 // Scopus Search API
 $results = $api


### PR DESCRIPTION
Its better to inject `ClientInterface` object instead of api key and timeout, as it allows to provide any `ClientInterface` based client with any options. To simply migration added default `ScopusApiFactory`.